### PR TITLE
Suzu: use proper USB pid

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -56,7 +56,7 @@ PRODUCT_AAPT_PREF_CONFIG := xxhdpi
 
 PRODUCT_PROPERTY_OVERRIDES := \
     ro.sf.lcd_density=480 \
-    ro.usb.pid_suffix=1DB
+    ro.usb.pid_suffix=1E0
 
 # Inherit from those products. Most specific first.
 $(call inherit-product, device/sony/loire/platform.mk)


### PR DESCRIPTION
Picked from 34.0.A.1.277

Signed-off-by: David Viteri davidteri91@gmail.com
