### PR TITLE
mixer_paths: rename to suit new audio HAL

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -23,7 +23,7 @@ PRODUCT_COPY_FILES := \
     device/sony/suzu/rootdir/system/etc/thermanager.xml:system/etc/thermanager.xml \
     device/sony/suzu/rootdir/system/etc/libnfc-brcm.conf:system/etc/libnfc-brcm.conf \
     device/sony/suzu/rootdir/system/etc/libnfc-nxp.conf:system/etc/libnfc-nxp.conf \
-    device/sony/suzu/rootdir/system/etc/mixer_paths.xml:system/etc/mixer_paths.xml
+    device/sony/suzu/rootdir/system/etc/mixer_paths.xml:system/etc/mixer_paths_wcd9335.xml
 
 # Device Specific Permissions
 PRODUCT_COPY_FILES += \


### PR DESCRIPTION
The new HAL is in CAF style with mixer_path file name determined by SoC type.

Signed-off-by: Adam Farden adam@farden.cz
