### PR TITLE
[master] sony: suzu: Remove double tap to wake option for now

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -89,7 +89,7 @@
     <integer name="config_screenBrightnessDark">5</integer>
 
     <!-- Whether device supports double tap to wake -->
-    <bool name="config_supportDoubleTapWake">true</bool>
+    <bool name="config_supportDoubleTapWake">false</bool>
 
     <!-- MMS user agent prolfile url -->
     <string name="config_mms_user_agent_profile_url" translatable="false">http://uaprof.sonymobile.com/F5121R3401.xml</string>


### PR DESCRIPTION
This feature is causing suspend/resume problems for touchscreen.

So, this patch removes it for now while we haven't the proper fix.

Signed-off-by: Humberto Borba humberos@gmail.com
