### PR TITLE
sony: suzu: Do not trigger power HAL with wakeup gesture

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -18,4 +18,4 @@ TARGET_BOOTLOADER_BOARD_NAME := F5121
 
 BOARD_KERNEL_CMDLINE += androidboot.hardware=suzu
 
-TARGET_TAP_TO_WAKE_NODE := "/sys/devices/virtual/input/clearpad/wakeup_gesture"
+#TARGET_TAP_TO_WAKE_NODE := "/sys/devices/virtual/input/clearpad/wakeup_gesture"


### PR DESCRIPTION
Wakeup gesture is disabled so do not trigger power HAL
by commenting out TARGET_TAP_TO_WAKE_NODE flag.

Signed-off-by: Humberto Borba humberos@gmail.com
