### PR TITLE
[master] sony: suzu: Update nfc device node name

### DIFF
--- a/rootdir/system/etc/libnfc-nxp.conf
+++ b/rootdir/system/etc/libnfc-nxp.conf
@@ -19,7 +19,7 @@ NXPLOG_TML_LOGLEVEL=0x01
 
 ###############################################################################
 # Nfc Device Node name
-NXP_NFC_DEV_NODE="/dev/pn544"
+NXP_NFC_DEV_NODE="/dev/pn54x"
 
 ###############################################################################
 # File name for Firmware


### PR DESCRIPTION
Fix NFC for android-7.1.1_r4 by updating its node name.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I10621da33312ec951d40e8194588c53a05058e67