### PR TITLE
[master] sony: suzu: Fix audio routing

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -23,7 +23,7 @@ PRODUCT_COPY_FILES := \
     device/sony/suzu/rootdir/system/etc/thermanager.xml:system/etc/thermanager.xml \
     device/sony/suzu/rootdir/system/etc/libnfc-brcm.conf:system/etc/libnfc-brcm.conf \
     device/sony/suzu/rootdir/system/etc/libnfc-nxp.conf:system/etc/libnfc-nxp.conf \
-    device/sony/suzu/rootdir/system/etc/mixer_paths.xml:system/etc/mixer_paths_wcd9335.xml
+    device/sony/suzu/rootdir/system/etc/mixer_paths.xml:system/etc/mixer_paths.xml
 
 # Device Specific Permissions
 PRODUCT_COPY_FILES += \


### PR DESCRIPTION
System (at 7.1.1_r4) is expecting mixer_paths.xml as filename.

08-18 15:12:03.790   476   476 E audio_route: Failed to open /system/etc/mixer_paths.xml
08-18 15:12:03.793   476   476 E msm8916_platform: platform_init: Failed to init audio route controls, aborting.
08-18 15:12:03.804   476   476 E audio_hw_primary: adev_open: Failed to init platform data, aborting.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I9aea0ebebe9ce273e5713fc2c327f78584eb07d6