### PR TITLE
[master] sony: suzu: Fix audio for video recording

### DIFF
--- a/rootdir/system/etc/mixer_paths.xml
+++ b/rootdir/system/etc/mixer_paths.xml
@@ -2564,9 +2564,10 @@
     </path>
 
     <path name="camcorder-mic">
-        <path name="camcorder-mic-common" />
-        <ctl name="DEC8 Volume" value="101" />
-        <ctl name="DEC7 Volume" value="83" />
+        <path name="handset-mic" />
+        <ctl name="SLIM_0_TX Format" value="S16_LE" />
+        <ctl name="DEC8 Volume" value="125" />
+        <ctl name="DEC7 Volume" value="107" />
     </path>
 
     <path name="camcorder-mic-gain-low">


### PR DESCRIPTION
For some reason dual mic is not working on aosp hal.
So disable it and use only one channel for audio
during video recording.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I78c00634d55d009e477effa6ed16d7d3e0078c98