### PR TITLE
Turn off secondary MIC while using stereo-mic

### DIFF
--- a/rootdir/system/etc/mixer_paths.xml
+++ b/rootdir/system/etc/mixer_paths.xml
@@ -2088,6 +2088,7 @@
     <path name="speaker-mic">
         <path name="dmic4" />
         <path name="dmic2-adj-gain" />
+        <ctl name="RX7 Digital Volume" value="0" />
     </path>
 
     <path name="stereo-mic-common">


### PR DESCRIPTION
When making SIP Voip calls both speakers are used in speaker mode
which results in echo issues. Turn off bottom speaker as in the
case of voice/voip speaker calls.