### PR TITLE
[SUZU] thermal: Add backlight burnout protection

### DIFF
--- a/rootdir/vendor/etc/thermanager.xml
+++ b/rootdir/vendor/etc/thermanager.xml
@@ -58,6 +58,9 @@
 		<!-- hotplugging -->
 		<resource name="thermal-max-cpus" type="sysfs">/sys/devices/system/cpu/cpuquiet/nr_thermal_max_cpus</resource>
 
+		<!-- display backlight -->
+		<resource name="disp-bl" type="sysfs">/sys/class/leds/lcd-backlight/max_brightness</resource>
+		
 		<!-- device-specific -->
 		<resource name="adreno-max-clk" type="sysfs">/sys/class/kgsl/kgsl-3d0/max_gpuclk</resource>
 		<resource name="charge_speed" type="sysfs">/sys/class/power_supply/battery/system_temp_level</resource>
@@ -131,6 +134,14 @@
 		<mitigation level="11"><value resource="charge_speed">11</value></mitigation>
 		<mitigation level="12"><value resource="charge_speed">12</value></mitigation>
 		<mitigation level="13"><value resource="charge_speed">13</value></mitigation>
+	</control>
+
+	<control name="backlight">
+		<mitigation level="off"><value resource="disp-bl">255</value></mitigation>
+		<mitigation level="1"><value resource="disp-bl">220</value></mitigation>
+		<mitigation level="2"><value resource="disp-bl">170</value></mitigation>
+		<mitigation level="3"><value resource="disp-bl">120</value></mitigation>
+		<mitigation level="4"><value resource="disp-bl">60</value></mitigation>
 	</control>
 
 	<!-- CPU A53 -->
@@ -276,6 +287,25 @@
 		</threshold>
 		<threshold trigger="67000" clear="50000">
 			<mitigation name="shutdown" level="1" />
+		</threshold>
+	</configuration>
+
+	<!-- display backlight burnout protection -->
+	<configuration sensor="case_therm">
+		<threshold>
+			<mitigation name="backlight" level="off" />
+		</threshold>
+		<threshold trigger="420" clear="400">
+			<mitigation name="backlight" level="1" />
+		</threshold>
+		<threshold trigger="480" clear="450">
+			<mitigation name="backlight" level="2" />
+		</threshold>
+		<threshold trigger="510" clear="490">
+			<mitigation name="backlight" level="3" />
+		</threshold>
+		<threshold trigger="700" clear="600">
+			<mitigation name="backlight" level="4" />
 		</threshold>
 	</configuration>
 


### PR DESCRIPTION
Under certain heat conditions, it is possible to burn the backlight
LEDs and/or controller.
Mitigate backlight values to prevent burnout.