### PR TITLE
rootdir: vendor: increase speaker volume

### DIFF
--- a/rootdir/vendor/etc/mixer_paths.xml
+++ b/rootdir/vendor/etc/mixer_paths.xml
@@ -1826,8 +1826,8 @@
         <ctl name="SLIM_0_RX Channels" value="Two" />
         <ctl name="RX INT7_1 MIX1 INP0" value="RX0" />
         <ctl name="RX INT8_1 MIX1 INP0" value="RX1" />
-        <ctl name="RX7 Digital Volume" value="86" />
-        <ctl name="RX8 Digital Volume" value="86" />
+        <ctl name="RX7 Digital Volume" value="92" />
+        <ctl name="RX8 Digital Volume" value="92" />
         <ctl name="SpkrLeft COMP Switch" value="1" />
         <ctl name="SpkrRight COMP Switch" value="1" />
         <ctl name="SpkrLeft BOOST Switch" value="1" />


### PR DESCRIPTION
Increase volume to 92 to achieve acceptable loudness with minimal distortion.
I'm not certain if If the value of 92 is actually applicable for suzu, that is unknown. The sole purpose of this PR is to keep suzu synced up with kugo after a similar change was done in https://github.com/sonyxperiadev/device-sony-kugo/commit/1546214d75dc8ec3778c4e390f42613009f07d36