### PR TITLE
Remove unnecessary NFC flags and packages

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -75,10 +75,6 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     power.suzu
 
-# NFC config
-PRODUCT_PACKAGES += \
-    nfc_nci.suzu
-
 # Telephony Packages (AOSP)
 PRODUCT_PACKAGES += \
     InCallUI \


### PR DESCRIPTION
* These packages and flags no longer exist
  in AOSP 9 codebase.