### PR TITLE
Fix NFC

### DIFF
--- a/rootdir/vendor/etc/libnfc-nci.conf
+++ b/rootdir/vendor/etc/libnfc-nci.conf
@@ -26,6 +26,24 @@ AID_FOR_EMPTY_SELECT={08:A0:00:00:01:51:00:00:00}
 SCREEN_OFF_POWER_STATE=1
 
 ###############################################################################
+# Force tag polling for the following technology(s).
+# The bits are defined as tNFA_TECHNOLOGY_MASK in nfa_api.h.
+# Default is NFA_TECHNOLOGY_MASK_A | NFA_TECHNOLOGY_MASK_B |
+#            NFA_TECHNOLOGY_MASK_F | NFA_TECHNOLOGY_MASK_ISO15693 |
+#            NFA_TECHNOLOGY_MASK_B_PRIME | NFA_TECHNOLOGY_MASK_KOVIO |
+#            NFA_TECHNOLOGY_MASK_A_ACTIVE | NFA_TECHNOLOGY_MASK_F_ACTIVE.
+#
+# Notable bits:
+# NFA_TECHNOLOGY_MASK_A             0x01    /* NFC Technology A             */
+# NFA_TECHNOLOGY_MASK_B             0x02    /* NFC Technology B             */
+# NFA_TECHNOLOGY_MASK_F             0x04    /* NFC Technology F             */
+# NFA_TECHNOLOGY_MASK_ISO15693      0x08    /* Proprietary Technology       */
+# NFA_TECHNOLOGY_MASK_KOVIO         0x20    /* Proprietary Technology       */
+# NFA_TECHNOLOGY_MASK_A_ACTIVE      0x40    /* NFC Technology A active mode */
+# NFA_TECHNOLOGY_MASK_F_ACTIVE      0x80    /* NFC Technology F active mode */
+POLLING_TECH_MASK=0xEF
+
+###############################################################################
 # Override the stack default for NFA_EE_MAX_EE_SUPPORTED set in nfc_target.h.
 # The value is set to 3 by default as it assumes we will discover 0xF2,
 # 0xF3, and 0xF4. If a platform will exclude and SE, this value can be reduced

--- a/rootdir/vendor/etc/libnfc-nxp.conf
+++ b/rootdir/vendor/etc/libnfc-nxp.conf
@@ -16,6 +16,7 @@ NXPLOG_NCIX_LOGLEVEL=0x01
 NXPLOG_NCIR_LOGLEVEL=0x01
 NXPLOG_FWDNLD_LOGLEVEL=0x01
 NXPLOG_TML_LOGLEVEL=0x01
+NFC_DEBUG_ENABLED=0
 
 ###############################################################################
 # Nfc Device Node name


### PR DESCRIPTION
Bring back the POLLING_TECH_MASK config entry
and set it to force tag polling for all available techs.
Without this config the chip will not work properly.

Also, since NFC now works then do not populate/spam the logs
with unnecessary information, at least for now.

