### PR TITLE
device: copy nvram to path required by brcmfmac

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -64,6 +64,10 @@ PRODUCT_COPY_FILES += \
 # WIFI FW patch
 PRODUCT_COPY_FILES += \
     $(DEVICE_PATH)/vendor/firmware/bcmdhd.cal:$(TARGET_COPY_OUT_VENDOR)/firmware/bcmdhd.cal
+ifeq ($(WIFI_DRIVER_BUILT),brcmfmac)
+PRODUCT_COPY_FILES += \
+    $(DEVICE_PATH)/vendor/firmware/bcmdhd.cal:$(TARGET_COPY_OUT_VENDOR)/firmware/brcm/brcmfmac43455-sdio.txt
+endif
 
 # Device Init
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
brcmfmac requires for the firmware files to be located under brcm/ and to follow a naming format.
Consider that when brcmfmac is used.